### PR TITLE
Add knowledge retrieval tool integration

### DIFF
--- a/src/prp_compiler/agents/planner.py
+++ b/src/prp_compiler/agents/planner.py
@@ -65,6 +65,26 @@ class PlannerAgent(BaseAgent):
             }
         )
 
+        # Provide a built-in action for retrieving information from the
+        # KnowledgeStore. This does not rely on any primitives on disk so the
+        # planner always has access to it.
+        actions.append(
+            {
+                "name": "retrieve_knowledge",
+                "description": "Search the knowledge store for relevant information.",
+                "inputs_schema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "The search query to retrieve information for.",
+                        }
+                    },
+                    "required": ["query"],
+                },
+            }
+        )
+
         gemini_tools = []
         for action in actions:
             # Start with the base schema from the manifest

--- a/src/prp_compiler/orchestrator.py
+++ b/src/prp_compiler/orchestrator.py
@@ -30,6 +30,13 @@ class Orchestrator:
     def execute_action(self, action: Action) -> str:
         """Dynamically loads and executes an action primitive from its file path."""
         try:
+            # Built-in retrieval bypasses the primitive loader and directly
+            # queries the KnowledgeStore.
+            if action.tool_name == "retrieve_knowledge":
+                query = action.arguments.get("query", "")
+                chunks = self.knowledge_store.retrieve(query)
+                return "\n".join(chunks)
+
             actions = self.primitive_loader.primitives.get("actions", {})
             action_manifest = actions.get(action.tool_name)
             if not action_manifest:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -13,6 +13,19 @@ def mock_knowledge_store():
     return MagicMock()
 
 
+@patch("src.prp_compiler.orchestrator.PlannerAgent")
+def test_execute_action_retrieve_knowledge(MockPlannerAgent, mock_knowledge_store):
+    """execute_action should return joined chunks from the knowledge store."""
+    orchestrator = Orchestrator(MagicMock(primitives={}), mock_knowledge_store)
+    mock_knowledge_store.retrieve.return_value = ["ChunkA", "ChunkB"]
+
+    action = Action(tool_name="retrieve_knowledge", arguments={"query": "foo"})
+    result = orchestrator.execute_action(action)
+
+    mock_knowledge_store.retrieve.assert_called_once_with("foo")
+    assert result == "ChunkA\nChunkB"
+
+
 @patch("importlib.util.module_from_spec")
 @patch("importlib.util.spec_from_file_location")
 def test_execute_action_dynamically_imports_and_runs_function(


### PR DESCRIPTION
## Summary
- add a built-in `retrieve_knowledge` tool in `PlannerAgent`
- intercept this action in `Orchestrator.execute_action`
- test planner tool schema and orchestrator retrieval

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install --quiet typer[all] google-generativeai python-dotenv PyYAML pydantic tiktoken langchain langchain-community langchain-google-genai langchain-openai chromadb semantic-version jsonschema` *(fails: Could not find a version that satisfies the requirement google-generativeai)*

------
https://chatgpt.com/codex/tasks/task_b_6872fc7f84148330869c04ee67d5a1c4