### PR TITLE
Update default primitive paths

### DIFF
--- a/src/prp_compiler/config.py
+++ b/src/prp_compiler/config.py
@@ -8,9 +8,9 @@ from dotenv import load_dotenv
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 
 # Define default paths relative to the project root.
-DEFAULT_TOOLS_PATH = PROJECT_ROOT / "agent_capabilities/tools"
-DEFAULT_KNOWLEDGE_PATH = PROJECT_ROOT / "agent_capabilities/knowledge"
-DEFAULT_SCHEMAS_PATH = PROJECT_ROOT / "agent_capabilities/schemas"
+DEFAULT_TOOLS_PATH = PROJECT_ROOT / "agent_primitives/actions"
+DEFAULT_KNOWLEDGE_PATH = PROJECT_ROOT / "agent_primitives/knowledge"
+DEFAULT_SCHEMAS_PATH = PROJECT_ROOT / "agent_primitives/schemas"
 DEFAULT_MANIFEST_PATH = PROJECT_ROOT / "manifests/"
 
 # Allowlist for shell commands to prevent arbitrary code execution.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,10 +26,10 @@ def mock_configure_gemini(monkeypatch):
 @pytest.fixture(scope="session")
 def temp_agent_dir(tmp_path_factory):
     """
-    Creates a temporary agent_capabilities directory with dummy files for
+    Creates a temporary agent_primitives directory with dummy files for
     session-wide use.
     """
-    base_path = tmp_path_factory.mktemp("agent_capabilities_session")
+    base_path = tmp_path_factory.mktemp("agent_primitives_session")
 
     # Define paths
     schemas_path = base_path / "schemas"


### PR DESCRIPTION
## Summary
- update config's default primitive paths to `agent_primitives`
- fix tests using temporary path names

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6872fe4cd410833086c379e9cf7b8f39