### PR TITLE
Fix orchestrator and golden tests

### DIFF
--- a/tests/test_golden_set.py
+++ b/tests/test_golden_set.py
@@ -101,6 +101,9 @@ def test_golden_prp(
 
     mock_llm_instance = mock_generative_model.return_value
     mock_llm_instance.generate_content.side_effect = [
+        make_mock_planner_response(
+            "select_strategy", {"strategy_name": "simple_feature_strategy"}
+        ),
         mock_planner_step1,
         mock_planner_step2,
         mock_synthesizer_response,
@@ -116,6 +119,8 @@ def test_golden_prp(
             vector_db_path=Path(tmp_path / "chroma_db"),
             constitution_path=Path("non_existent_file.md"),
             cache_db_path=Path(tmp_path / "cache.sqlite"),
+            strategy=None,
+            plan_file=None,
         )
         # We expect this to succeed
         exit_code = 0

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -113,9 +113,11 @@ def test_run_captures_finish_args_and_assembles_context(
 
     # The loader is still needed for schemas and patterns
     mock_loader = MagicMock()
+    strategy_content = "This is a simple strategy."
     mock_loader.get_primitive_content.side_effect = [
-        '{"title": "Test Schema"}',  # First call for the schema
-        'This is a test pattern.'   # Second call for the pattern
+        strategy_content,             # First call for the strategy
+        '{"title": "Test Schema"}',  # Second call for the schema
+        'This is a test pattern.'     # Third call for the pattern
     ]
 
     orchestrator = Orchestrator(mock_loader, mock_knowledge_store, MagicMock())
@@ -126,11 +128,13 @@ def test_run_captures_finish_args_and_assembles_context(
         "test goal", "test constitution"
     )
 
-    mock_planner_instance.select_strategy.assert_called_once_with("test goal", "test constitution")
+    mock_planner_instance.select_strategy.assert_called_once_with(
+        "test goal", "test constitution"
+    )
     mock_planner_instance.plan_step.assert_any_call(
         "test goal",
         "test constitution",
-        orchestrator.primitive_loader.get_primitive_content.return_value,
+        strategy_content,
         ANY,
     )
 


### PR DESCRIPTION
## Summary
- update golden tests to supply optional arguments and mock strategy selection
- ensure orchestrator test mocks strategy, schema and pattern loading

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_b_68731be82764833093263e42b82395bb