### PR TITLE
Fix result cache validation before early return

### DIFF
--- a/src/prp_compiler/orchestrator.py
+++ b/src/prp_compiler/orchestrator.py
@@ -43,7 +43,7 @@ class Orchestrator:
         cache_key = self._compute_action_cache_key(action)
         if self.result_cache:
             cached = self.result_cache.get(cache_key)
-            if cached:
+            if isinstance(cached, dict) and "result" in cached:
                 return cached["result"]
         try:
             # Built-in retrieval bypasses the primitive loader and directly
@@ -100,7 +100,11 @@ class Orchestrator:
         cache_key = self._compute_cache_key(user_goal)
         if self.result_cache:
             cached = self.result_cache.get(cache_key)
-            if cached:
+            if (
+                isinstance(cached, dict)
+                and "schema_choice" in cached
+                and "final_context" in cached
+            ):
                 return cached["schema_choice"], cached["final_context"]
 
         # STEP 1: Select Strategy


### PR DESCRIPTION
## Summary
- ensure cached structures have expected fields before using them

## Testing
- `pytest -k orchestrator -vv` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_b_68731e5ce3648330a11fa9bc2e7b740d