### PR TITLE
[prp-compiler] Add constitution, caching, dynamic context resolution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -70,3 +70,5 @@ This loop continues until the agent concludes it has sufficient context to gener
 
 ### 5. The Synthesizer Agent
 A simpler agent that receives the final, rich context from the Planner and a chosen output schema. Its sole job is to arrange the context into the structure defined by the schema, producing a final, validated JSON output.
+
+The orchestrator caches results of expensive steps and resolves dynamic content references before synthesis.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,13 @@
 # Agent Constitution (CLAUDE.md)
 
-This document outlines the core principles and operational guidelines for all agents within this system.
+This document outlines the core principles for all agents in this system.
 
-1.  **Primary Objective:** The agent's primary objective is to assist the user in generating high-quality, well-structured Prompt-Response-Pairs (PRPs) by accurately interpreting their goals and leveraging the provided capabilities.
+1.  **Primary Objective:** Your primary objective is to generate a high-quality, comprehensive, and actionable Product Requirement Prompt (PRP) that empowers a developer or another AI to implement a feature correctly on the first pass.
 
-2.  **Security First:** Never execute commands or access files that are not explicitly part of the user-defined plan. All dynamic operations must be treated with caution.
+2.  **Clarity and Structure:** The final PRP must be clear, well-structured, and strictly adhere to the chosen output schema. All sections must be filled with relevant, synthesized information.
 
-3.  **Clarity and Precision:** The agent must strive for clarity and precision in its output. The generated PRP should be unambiguous and directly address the user's goal.
+3.  **Context is King:** Your reasoning must be grounded in the context you gather. Prioritize information from the local codebase and curated knowledge base over general knowledge. Explicitly state your sources in your reasoning.
 
-4.  **Efficiency:** The agent should select the most relevant tools and knowledge to assemble a concise and effective context, avoiding unnecessary information that could dilute the prompt's focus or exceed token limits.
+4.  **Efficiency and Focus:** Do not perform unnecessary actions. Select only the tools and knowledge primitives that are most relevant to the user's specific goal. Every step in your plan should have a clear purpose.
+
+5.  **Critical Self-Correction:** Continuously critique your own plan. Before finalizing, ask yourself if the context is sufficient and if the plan is logical.

--- a/README.md
+++ b/README.md
@@ -67,3 +67,5 @@ We welcome new primitives and improvements! See [CONTRIBUTING.md](CONTRIBUTING.m
 
 For an in-depth look at the system architecture, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
+
+The compiler now supports result caching and dynamic context resolution. Use repeated runs to benefit from cache hits and embed file contents or command output in patterns using the @() and !() syntax.

--- a/agent_primitives/strategies/detailed_feature_strategy/1.0.0/manifest.yml
+++ b/agent_primitives/strategies/detailed_feature_strategy/1.0.0/manifest.yml
@@ -1,0 +1,5 @@
+name: "detailed_feature_strategy"
+type: "strategy"
+version: "1.0.0"
+description: "A detailed, multi-phase strategy for complex features. Guides the agent through codebase analysis, knowledge retrieval, and external research."
+entrypoint: "template.md"

--- a/agent_primitives/strategies/detailed_feature_strategy/1.0.0/template.md
+++ b/agent_primitives/strategies/detailed_feature_strategy/1.0.0/template.md
@@ -1,0 +1,17 @@
+# Detailed Feature Strategy
+
+## Initial Understanding
+Summarize the user's goal:
+{user_goal}
+
+## History
+{history}
+
+## Available Tools
+{tools_json_schema}
+
+Use a multi-phase approach:
+1. Analyze the codebase and retrieve relevant knowledge.
+2. Perform additional research if necessary.
+3. Continue iterating until confident in the final plan.
+4. Call the `finish` action with your chosen schema and patterns.

--- a/src/prp_compiler/config.py
+++ b/src/prp_compiler/config.py
@@ -15,6 +15,8 @@ DEFAULT_TOOLS_PATH = PROJECT_ROOT / "agent_primitives/actions"
 DEFAULT_KNOWLEDGE_PATH = PROJECT_ROOT / "agent_primitives/knowledge"
 DEFAULT_SCHEMAS_PATH = PROJECT_ROOT / "agent_primitives/schemas"
 DEFAULT_MANIFEST_PATH = PROJECT_ROOT / "manifests/"
+# Allowed shell commands for dynamic content resolution.
+ALLOWED_SHELL_COMMANDS = ["echo", "ls"]
 
 
 


### PR DESCRIPTION
## Summary
- update `CLAUDE.md` with constitution principles
- allow only certain shell commands in config
- resolve `!()` and `@()` references in `Orchestrator`
- add detailed feature strategy primitive
- improve planner template formatting
- extend orchestrator tests for dynamic content
- document caching and dynamic context

## Testing
- `python3 -m src.prp_compiler.scripts lint` *(fails: ruff not installed)*
- `python3 -m src.prp_compiler.scripts validate` *(fails: mypy not installed)*
- `python3 -m pytest` *(fails: pytest not installed)*

------
https://chatgpt.com/codex/tasks/task_b_687329a00d0883309c6526641c58644c