### PR TITLE
[prp-compiler] improve docs and expose version

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ prp-compiler serve --workers 4
 
 This starts a simple async queue processor that can handle multiple PRP compilation jobs concurrently.
 
+## Development Quickstart
+
+New contributors can get up and running quickly using the `uv` command wrapper
+defined in `pyproject.toml`.
+
+```bash
+uv run lint      # style check via Ruff
+uv run validate  # static type analysis with mypy
+uv run pytest    # run the full test suite
+```
+
+Run `uv sync` whenever dependencies change to ensure your environment matches the
+project configuration.
+
 ## Contributing
 
 We welcome new primitives and improvements! See [CONTRIBUTING.md](CONTRIBUTING.md) for details on the curation workflow and development process.

--- a/src/prp_compiler/__init__.py
+++ b/src/prp_compiler/__init__.py
@@ -1,0 +1,18 @@
+"""Core package for the PRP Compiler."""
+
+from importlib import metadata
+
+
+def _get_version() -> str:
+    """Return the installed package version or a fallback."""
+    try:
+        return metadata.version("prp-compiler")
+    except metadata.PackageNotFoundError:
+        # Package is not installed; use the version from pyproject for sources
+        return "0.1.0"
+
+
+__version__ = _get_version()
+
+__all__ = ["__version__"]
+


### PR DESCRIPTION
## Summary
- document development workflow commands in the README
- add package docstring and expose `__version__`

## Testing
- `uv run lint` *(fails: unsuccessful tunnel)*
- `uv run validate` *(fails: unsuccessful tunnel)*
- `uv run pytest` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_b_68732f1593f48330bdfa5bf0640ad0ba