### PR TITLE
[prp-compiler] Fix template formatting and secure action injection

### DIFF
--- a/src/prp_compiler/agents/planner.py
+++ b/src/prp_compiler/agents/planner.py
@@ -113,7 +113,7 @@ class PlannerAgent(BaseAgent):
     def select_strategy(self, user_goal: str, constitution: str) -> str:
         prompt = constitution + "\n\n" + STRATEGY_SELECTION_PROMPT.format(
             user_goal=user_goal,
-            strategies_json_schema=json.dumps(self.strategies_schema, indent=2),
+            strategies_json_schema=json.dumps(self.strategies_schema, indent=2).replace("{", "{{").replace("}", "}}"),
         )
         response = self.model.generate_content(prompt, tools=self.strategies_schema)
         fc = response.candidates[0].content.parts[0].function_call
@@ -129,7 +129,11 @@ class PlannerAgent(BaseAgent):
         history: List[str],
     ) -> ReActStep:
         """Perform a single ReAct planning step using the provided strategy template."""
-        variables = {"user_goal": user_goal, "tools_json_schema": json.dumps(self.actions_schema, indent=2), "history": "\n".join(history)}
+        variables = {
+            "user_goal": user_goal,
+            "tools_json_schema": json.dumps(self.actions_schema, indent=2).replace("{", "{{").replace("}", "}}"),
+            "history": "\n".join(history),
+        }
         try:
             strategy_prompt = strategy_content.format(**variables)
         except KeyError as e:

--- a/src/prp_compiler/agents/synthesizer.py
+++ b/src/prp_compiler/agents/synthesizer.py
@@ -28,7 +28,8 @@ class SynthesizerAgent(BaseAgent):
             constitution
             + "\n\n"
             + SYNTHESIZER_PROMPT_TEMPLATE.format(
-                json_schema=json.dumps(schema, indent=2), context=context
+                json_schema=json.dumps(schema, indent=2).replace("{", "{{").replace("}", "}}"),
+                context=context,
             )
         )
 

--- a/src/prp_compiler/orchestrator.py
+++ b/src/prp_compiler/orchestrator.py
@@ -102,10 +102,9 @@ class Orchestrator:
                 raise ImportError(f"Could not create module spec for {entrypoint_path}")
 
             action_module = importlib.util.module_from_spec(spec)
-            # Inject secure subprocess runner
-            if hasattr(action_module, 'subprocess_run'):
-                action_module.subprocess_run = secure_subprocess_run  # type: ignore
             spec.loader.exec_module(action_module)
+            # Always inject secure subprocess runner so actions can use `subprocess_run`
+            action_module.subprocess_run = secure_subprocess_run  # type: ignore
 
             action_function = getattr(action_module, function_str)
 


### PR DESCRIPTION
## Summary
- escape braces when inserting JSON into prompt templates
- always inject secure subprocess wrapper for actions

## Testing
- `uv run lint` *(fails: Failed to download `openai==1.95.0`)*
- `uv run validate` *(fails: Failed to download `openai==1.95.0`)*
- `uv run pytest` *(fails: Failed to download `openai==1.95.0`)*

------
https://chatgpt.com/codex/tasks/task_b_6873bcfaca5483309121cbd27bccf776